### PR TITLE
Fix neutrals interpolation indexing

### DIFF
--- a/EBdyna/G_eq/GT_eq.m
+++ b/EBdyna/G_eq/GT_eq.m
@@ -620,7 +620,7 @@ time_stamp=1;
                     if par.N0_FAC_D2>0
                         [neutral_density(COLL_GROUP),neutral_density_D2(COLL_GROUP)]=neutrals_2D_interp(x(COLL_GROUP,:));
                     else
-                        [neutral_density(COLL_GROUP),~]=neutrals_2D_interp(x(COLL_GROUP));
+                        [neutral_density(COLL_GROUP),~]=neutrals_2D_interp(x(COLL_GROUP,:));
                     end
                 end
                 if par.USE_T0_TABLE


### PR DESCRIPTION
## Summary
- fix neutrals 2D interpolation call when 2D maps are disabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683d9cc6a85883329f24bfc88a4cb238